### PR TITLE
Add electron react app scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
 # Nimbus
+
+Minimal cross-platform note taking app built with Electron and React.
+
+## Development
+
+```bash
+npm install # may require internet access
+npm run dev
+```
+
+## Build
+
+```bash
+npm run build
+```
+
+## Test
+
+```bash
+npm test
+npm run test:e2e
+```

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,0 +1,34 @@
+import { app, BrowserWindow, shell, protocol } from 'electron';
+import path from 'node:path';
+
+let win: BrowserWindow | null = null;
+
+function createWindow() {
+  win = new BrowserWindow({
+    width: 800,
+    height: 600,
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js'),
+      contextIsolation: true,
+      nodeIntegration: false
+    }
+  });
+
+  win.loadURL(`file://${path.join(__dirname, '../render/index.html')}`);
+}
+
+app.whenReady().then(() => {
+  createWindow();
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+  });
+});
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') app.quit();
+});
+
+protocol.handle('https', request => {
+  shell.openExternal(request.url, { activate: true });
+  return null as any;
+});

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1,0 +1,5 @@
+import { contextBridge, ipcRenderer } from 'electron';
+
+contextBridge.exposeInMainWorld('api', {
+  drop: (data: unknown) => ipcRenderer.invoke('drop', data)
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Nimbus</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "nimbus",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "electron/main.js",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build && electron-builder",
+    "test": "vitest run",
+    "test:e2e": "cypress run"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "better-sqlite3": "^8.0.0",
+    "fuse.js": "^6.6.2"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0",
+    "electron": "^29.0.0",
+    "vite": "^4.5.0",
+    "typescript": "^5.0.0",
+    "electron-builder": "^24.0.0",
+    "vitest": "^0.34.0",
+    "@vitest/ui": "^0.34.0",
+    "cypress": "^13.1.0"
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,17 @@
+import React, { useState } from 'react';
+import Editor from './components/Editor';
+import Sidebar from './components/Sidebar';
+import NoteList from './components/NoteList';
+import useDragDrop from './hooks/useDragDrop';
+
+export default function App() {
+  const [notes, setNotes] = useState<string[]>([]);
+  useDragDrop(url => setNotes(n => [...n, url]));
+  return (
+    <div className="app">
+      <Sidebar />
+      <NoteList notes={notes} />
+      <Editor />
+    </div>
+  );
+}

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -1,0 +1,13 @@
+import React, { useState } from 'react';
+import { marked } from "marked";
+
+/** Live markdown editor with preview */
+export default function Editor() {
+  const [text, setText] = useState('');
+  return (
+    <div className="editor">
+      <textarea value={text} onChange={e => setText(e.target.value)} />
+      <div className="preview" dangerouslySetInnerHTML={{ __html: marked.parse(text) }} />
+    </div>
+  );
+}

--- a/src/components/LinkCard.tsx
+++ b/src/components/LinkCard.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+interface Props { url: string }
+
+export default function LinkCard({ url }: Props) {
+  return (
+    <div className="link-card">
+      <a href={url} target="_blank" rel="noreferrer">{url}</a>
+    </div>
+  );
+}

--- a/src/components/NoteList.tsx
+++ b/src/components/NoteList.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+interface Props { notes: string[] }
+
+export default function NoteList({ notes }: Props) {
+  return (
+    <ul className="note-list">
+      {notes.map((n, i) => <li key={i}>{n}</li>)}
+    </ul>
+  );
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function Sidebar() {
+  return (
+    <aside className="sidebar">
+      <h2>Tags</h2>
+      {/* tags placeholder */}
+    </aside>
+  );
+}

--- a/src/hooks/useDragDrop.ts
+++ b/src/hooks/useDragDrop.ts
@@ -1,0 +1,23 @@
+import { useEffect } from 'react';
+
+/**
+ * Handle drag and drop for text, urls and files
+ * @param onDrop called with dropped url or file path
+ */
+export default function useDragDrop(onDrop: (data: string) => void) {
+  useEffect(() => {
+    function handle(e: DragEvent) {
+      e.preventDefault();
+      const dt = e.dataTransfer;
+      if (!dt) return;
+      const url = dt.getData('text/uri-list') || dt.getData('text/plain');
+      if (url) onDrop(url);
+    }
+    window.addEventListener('drop', handle);
+    window.addEventListener('dragover', e => e.preventDefault());
+    return () => {
+      window.removeEventListener('drop', handle);
+      window.removeEventListener('dragover', e => e.preventDefault());
+    };
+  }, [onDrop]);
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './style.css';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/style.css
+++ b/src/style.css
@@ -1,0 +1,7 @@
+body{margin:0;font-family:sans-serif}
+.app{display:flex;height:100vh}
+.sidebar{width:200px;background:#eee;transition:background .3s}
+.note-list{flex:1;overflow:auto}
+.editor{flex:1;display:flex;flex-direction:column}
+.editor textarea{flex:1}
+@media (prefers-color-scheme: dark){body{background:#222;color:#eee}.sidebar{background:#333}}

--- a/test/e2e/spec.cy.ts
+++ b/test/e2e/spec.cy.ts
@@ -1,0 +1,6 @@
+describe('nimbus app', () => {
+  it('loads', () => {
+    cy.visit('http://localhost:3000');
+    cy.contains('Tags');
+  });
+});

--- a/test/useDragDrop.test.ts
+++ b/test/useDragDrop.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect, vi } from 'vitest';
+import useDragDrop from '../src/hooks/useDragDrop';
+
+describe('useDragDrop', () => {
+  it('calls onDrop on drop', () => {
+    const fn = vi.fn();
+    useDragDrop(fn);
+    const event = new DragEvent('drop', { dataTransfer: new DataTransfer() });
+    event.dataTransfer?.setData('text/plain', 'test');
+    window.dispatchEvent(event);
+    expect(fn).toHaveBeenCalledWith('test');
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "esnext",
+    "jsx": "react",
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist"
+  },
+  "include": ["src", "electron"],
+  "exclude": ["node_modules"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    outDir: 'dist/render'
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold electron+react+ts app
- add hooks and components
- add sample unit and e2e tests
- document usage

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run test:e2e` *(fails: cypress not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a970e8e708328ac91ddfe99c335e7